### PR TITLE
Updated guidedogsupplementpend...

### DIFF
--- a/rules/general-supplements/guidedogsupplementpending.json
+++ b/rules/general-supplements/guidedogsupplementpending.json
@@ -1,0 +1,412 @@
+{
+  "nodes": [
+    {
+      "id": "d4b75ff1-c189-4c99-befd-34a048ea36dc",
+      "name": "GuideDogServiceSupplement",
+      "type": "inputNode",
+      "position": {
+        "x": -90,
+        "y": 185
+      },
+      "content": {
+        "fields": [
+          {
+            "id": 18,
+            "field": "familyUnitInPay",
+            "name": "Family Unit In Pay",
+            "description": "Family unit is in pay.",
+            "dataType": "true-false",
+            "childFields": []
+          },
+          {
+            "id": 130,
+            "field": "guideOrServiceDogTeams",
+            "name": "Guide or Service Dog Teams",
+            "description": "Array of dogs with certification documentation types. The number of dogs indicates the number on the family unit, and their specific documentation.",
+            "dataType": "object-array",
+            "childFields": [
+              {
+                "id": 22,
+                "name": "Guide Dog Documentation Type",
+                "field": "guideDogDocumentationType",
+                "description": "The type of documentation received for the guide dog.",
+                "dataType": "text-input",
+                "validationCriteria": "certification, testBooked, certifiedRetired",
+                "validationType": "[=text]"
+              }
+            ]
+          },
+          {
+            "id": 90,
+            "field": "currentDate",
+            "name": "The Current Date",
+            "description": "This is the current date.",
+            "dataType": "date",
+            "validationCriteria": "1950-01-01",
+            "validationType": ">=",
+            "childFields": []
+          }
+        ]
+      }
+    },
+    {
+      "id": "ff32aa69-c432-4205-93f8-7f6e3c57c2f3",
+      "name": "Eligibility",
+      "type": "decisionTableNode",
+      "content": {
+        "hitPolicy": "first",
+        "inputs": [
+          {
+            "id": "a91c0dbe-4622-41b9-94cd-b5bff7ed1ffc",
+            "name": "Family Unit In Pay",
+            "type": "expression",
+            "field": "familyUnitInPay",
+            "defaultValue": "false"
+          },
+          {
+            "id": "811e33b5-5f7a-4719-a00d-5d8aaa4c6940",
+            "field": "guideOrServiceDogTeams",
+            "name": "Guide or Service Dog Teams"
+          }
+        ],
+        "outputs": [
+          {
+            "id": "e30caacc-23e4-40d8-b8f3-976bb5bc36f9",
+            "name": "IsEligible",
+            "type": "expression",
+            "field": "isEligible",
+            "defaultValue": "false"
+          }
+        ],
+        "rules": [
+          {
+            "_id": "1468e0db-8faf-468d-b9f7-54b8bdc7ea5d",
+            "_description": "",
+            "a91c0dbe-4622-41b9-94cd-b5bff7ed1ffc": "true",
+            "811e33b5-5f7a-4719-a00d-5d8aaa4c6940": "len($) > 0",
+            "e30caacc-23e4-40d8-b8f3-976bb5bc36f9": "true"
+          },
+          {
+            "_id": "9e372954-b632-40f6-8e6e-d34190cf0a1c",
+            "a91c0dbe-4622-41b9-94cd-b5bff7ed1ffc": "",
+            "811e33b5-5f7a-4719-a00d-5d8aaa4c6940": "",
+            "e30caacc-23e4-40d8-b8f3-976bb5bc36f9": "false"
+          }
+        ]
+      },
+      "position": {
+        "x": 505,
+        "y": 490
+      }
+    },
+    {
+      "id": "3d92a47a-f301-4481-a287-84fa41daec6a",
+      "name": "GuideDogServiceSupplement",
+      "type": "outputNode",
+      "position": {
+        "x": 1070,
+        "y": 210
+      },
+      "content": {
+        "fields": [
+          {
+            "id": 28,
+            "field": "isEligible",
+            "name": "Is Eligible",
+            "description": "General \"Is Eligible\" statement used in conjunction with supplement building to describe eligibility.",
+            "dataType": "true-false",
+            "childFields": []
+          },
+          {
+            "id": 58,
+            "field": "supplementAmount",
+            "name": "Supplement Amount",
+            "description": "General \"Supplement Amount\" field to define total supplement amount output for a specific supplement.",
+            "dataType": "number-input",
+            "validationCriteria": "0",
+            "validationType": ">=",
+            "childFields": []
+          },
+          {
+            "id": 65,
+            "field": "twoMonthEligibility",
+            "name": "Up To Two Months of Eligibility",
+            "description": "The date that a supplement is eligible to be issued until based on start date information provided.",
+            "dataType": "date",
+            "validationCriteria": "[2022-01-01, 2029-12-31]",
+            "validationType": "[date]",
+            "childFields": []
+          }
+        ]
+      }
+    },
+    {
+      "id": "f97bbcc0-aae0-4844-82eb-bfa8a7a150e3",
+      "name": "Eligible Dog Teams",
+      "type": "decisionTableNode",
+      "content": {
+        "hitPolicy": "first",
+        "inputs": [
+          {
+            "id": "2f0b7c62-ebb6-41db-a36e-2d6e83df5f3e",
+            "field": "isEligible",
+            "name": "Is eligible"
+          },
+          {
+            "id": "f06e8fde-1d31-4ad1-ae94-f8cf6fe0fddf",
+            "field": "pending",
+            "name": "Count of dog teams with booked tests",
+            "defaultValue": ""
+          },
+          {
+            "id": "75dd5e22-fdc4-4ee2-b8dd-edbdba505b3a",
+            "field": "currentDate",
+            "name": "The Current Date",
+            "defaultValue": "date('now')"
+          }
+        ],
+        "outputs": [
+          {
+            "id": "e30caacc-23e4-40d8-b8f3-976bb5bc36f9",
+            "name": "IsEligible",
+            "type": "expression",
+            "field": "isEligible",
+            "defaultValue": "false"
+          },
+          {
+            "id": "cee807c7-281e-4f2d-be5a-7be83372701a",
+            "field": "supplementAmount",
+            "name": "Supplement Amount"
+          },
+          {
+            "id": "04206b13-1572-446c-9877-14c28923c332",
+            "field": "twoMonthEligibility",
+            "name": "Up To Two Months of Eligibility"
+          }
+        ],
+        "rules": [
+          {
+            "_id": "e07580c9-79a4-46ec-b36a-8b0e0c6e9750",
+            "_description": "A test booked with the Justice Institute for certification for a date within two months of requesting the supplement for at least one of the teams.",
+            "2f0b7c62-ebb6-41db-a36e-2d6e83df5f3e": "true",
+            "f06e8fde-1d31-4ad1-ae94-f8cf6fe0fddf": "$ > 0",
+            "75dd5e22-fdc4-4ee2-b8dd-edbdba505b3a": "",
+            "e30caacc-23e4-40d8-b8f3-976bb5bc36f9": "",
+            "cee807c7-281e-4f2d-be5a-7be83372701a": "pending * 95",
+            "04206b13-1572-446c-9877-14c28923c332": "twoMonthsDate"
+          },
+          {
+            "_id": "6243ad86-e852-401b-a7af-c165256c02a7",
+            "2f0b7c62-ebb6-41db-a36e-2d6e83df5f3e": "",
+            "f06e8fde-1d31-4ad1-ae94-f8cf6fe0fddf": "",
+            "75dd5e22-fdc4-4ee2-b8dd-edbdba505b3a": "",
+            "e30caacc-23e4-40d8-b8f3-976bb5bc36f9": "false",
+            "cee807c7-281e-4f2d-be5a-7be83372701a": "",
+            "04206b13-1572-446c-9877-14c28923c332": ""
+          }
+        ]
+      },
+      "position": {
+        "x": 775,
+        "y": 205
+      }
+    },
+    {
+      "type": "expressionNode",
+      "content": {
+        "expressions": [
+          {
+            "id": "eda9de75-be42-470e-8538-99aea2de0d00",
+            "key": "certified",
+            "value": "count(guideOrServiceDogTeams, (#.guideDogDocumentationType == 'certification'))"
+          },
+          {
+            "id": "7c89301f-b8a0-4f0b-99ef-a5c0bdd1bf08",
+            "key": "pending",
+            "value": "count(guideOrServiceDogTeams, (#.guideDogDocumentationType == 'testBooked'))"
+          },
+          {
+            "id": "a580083f-8854-49b1-b5bc-317045c966d1",
+            "key": "retired",
+            "value": "count(guideOrServiceDogTeams, (#.guideDogDocumentationType == 'certifiedRetired'))"
+          }
+        ]
+      },
+      "id": "213b1bcf-0443-4de3-93b6-6644efd409ef",
+      "name": "Dog Team Count",
+      "position": {
+        "x": 505,
+        "y": 390
+      }
+    },
+    {
+      "type": "switchNode",
+      "content": {
+        "hitPolicy": "first",
+        "statements": [
+          {
+            "id": "6f4a4ff1-0135-4633-a148-d52d88dc6a39",
+            "condition": "guideOrServiceDogTeams != null",
+            "isDefault": false
+          },
+          {
+            "id": "d1b49062-f9f5-4f1c-a911-0fab03b714d2",
+            "condition": "",
+            "isDefault": true
+          }
+        ]
+      },
+      "id": "0e67fe53-6035-45bb-92dc-08b271322328",
+      "name": "Check for any documentation",
+      "position": {
+        "x": 205,
+        "y": 185
+      }
+    },
+    {
+      "type": "customNode",
+      "content": {
+        "kind": "noteNode",
+        "config": {
+          "value": "If base eligibility passes, dog team count is based on the documentation available for each dog. If no documentation, they are not an eligible dog team. "
+        }
+      },
+      "id": "2c763cbe-bf93-4001-a4a2-ac3dda0ba998",
+      "name": "Note",
+      "position": {
+        "x": 505,
+        "y": 220
+      }
+    },
+    {
+      "type": "customNode",
+      "content": {
+        "kind": "noteNode",
+        "config": {
+          "value": "If base eligibility passes, and at least one dog team has the correct documentation, they are eligible for the supplement. Amount is based on the number of dog teams with documentation."
+        }
+      },
+      "id": "324df88e-49c9-4312-b525-5a322a1c38f6",
+      "name": "Note",
+      "position": {
+        "x": 775,
+        "y": 20
+      }
+    },
+    {
+      "type": "customNode",
+      "content": {
+        "kind": "noteNode",
+        "config": {
+          "value": "Determines eligibility for a temporary supplement for guide dog teams where the a test has been booked for a guide dog team, but they are not yet certified."
+        }
+      },
+      "id": "02c994c5-18b5-4cf1-a98c-c7da69844426",
+      "name": "Note",
+      "position": {
+        "x": -85,
+        "y": 0
+      }
+    },
+    {
+      "type": "functionNode",
+      "content": {
+        "source": "import dayjs from 'dayjs';\n\nexport const handler = async (input) => {\n  const currentDateString = (input.currentDate || new Date()).toString();\n  function addTwoMonths(dateString) {\n    return dayjs(dateString).add(2, 'month').format('YYYY-MM-DD');\n  }\n  const newDate = addTwoMonths(currentDateString);\n  console.log(newDate); // Outputs: '2024-12-24'\n  input.twoMonthsDate = newDate;\n  return input;\n};\n\n\n\n\n\n"
+      },
+      "id": "df68d89c-d3a2-423e-b82a-6ad40e2560fb",
+      "name": "2 Months Calculation",
+      "position": {
+        "x": 500,
+        "y": 105
+      }
+    },
+    {
+      "type": "customNode",
+      "content": {
+        "kind": "noteNode",
+        "config": {
+          "value": "A calculation of 2 months from the current or selected date is provided if any of the dog teams are 'test booked'. The date defaults to 2 months from the current date if no date given."
+        }
+      },
+      "id": "d2ceb295-3651-4ef7-ac6c-3553680c3347",
+      "name": "Note",
+      "position": {
+        "x": 505,
+        "y": -85
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "0a09ba8d-42ed-4ab6-b154-f342e4928b0c",
+      "sourceId": "ff32aa69-c432-4205-93f8-7f6e3c57c2f3",
+      "type": "edge",
+      "targetId": "f97bbcc0-aae0-4844-82eb-bfa8a7a150e3"
+    },
+    {
+      "id": "79a450d8-9689-47da-821a-f1b7edcfed0a",
+      "sourceId": "f97bbcc0-aae0-4844-82eb-bfa8a7a150e3",
+      "type": "edge",
+      "targetId": "3d92a47a-f301-4481-a287-84fa41daec6a"
+    },
+    {
+      "id": "8eaad5e1-7972-4e0f-b2f0-4dc160b229f5",
+      "sourceId": "213b1bcf-0443-4de3-93b6-6644efd409ef",
+      "type": "edge",
+      "targetId": "f97bbcc0-aae0-4844-82eb-bfa8a7a150e3"
+    },
+    {
+      "id": "f30bf4a3-9120-4428-bea0-578425eed943",
+      "sourceId": "d4b75ff1-c189-4c99-befd-34a048ea36dc",
+      "type": "edge",
+      "targetId": "0e67fe53-6035-45bb-92dc-08b271322328"
+    },
+    {
+      "id": "4158319d-c534-409d-a1fe-5c2f64ff160a",
+      "sourceId": "0e67fe53-6035-45bb-92dc-08b271322328",
+      "type": "edge",
+      "targetId": "213b1bcf-0443-4de3-93b6-6644efd409ef",
+      "sourceHandle": "6f4a4ff1-0135-4633-a148-d52d88dc6a39"
+    },
+    {
+      "id": "0c6abb27-b575-4d53-b14f-fe2cc767de35",
+      "sourceId": "0e67fe53-6035-45bb-92dc-08b271322328",
+      "type": "edge",
+      "targetId": "ff32aa69-c432-4205-93f8-7f6e3c57c2f3",
+      "sourceHandle": "6f4a4ff1-0135-4633-a148-d52d88dc6a39"
+    },
+    {
+      "id": "8f3f79fb-cc78-4eb7-81fe-a71a1ee8bf0d",
+      "sourceId": "0e67fe53-6035-45bb-92dc-08b271322328",
+      "type": "edge",
+      "targetId": "ff32aa69-c432-4205-93f8-7f6e3c57c2f3",
+      "sourceHandle": "d1b49062-f9f5-4f1c-a911-0fab03b714d2"
+    },
+    {
+      "id": "2646c38f-2aad-4a61-8f7f-cfab385cf663",
+      "sourceId": "ff32aa69-c432-4205-93f8-7f6e3c57c2f3",
+      "type": "edge",
+      "targetId": "3d92a47a-f301-4481-a287-84fa41daec6a"
+    },
+    {
+      "id": "17ef2304-4a57-407f-9e2e-28362f939645",
+      "sourceId": "0e67fe53-6035-45bb-92dc-08b271322328",
+      "type": "edge",
+      "targetId": "f97bbcc0-aae0-4844-82eb-bfa8a7a150e3",
+      "sourceHandle": "6f4a4ff1-0135-4633-a148-d52d88dc6a39"
+    },
+    {
+      "id": "856d43fb-ecdd-4841-8f13-cbe01c7b1702",
+      "sourceId": "0e67fe53-6035-45bb-92dc-08b271322328",
+      "type": "edge",
+      "targetId": "df68d89c-d3a2-423e-b82a-6ad40e2560fb",
+      "sourceHandle": "6f4a4ff1-0135-4633-a148-d52d88dc6a39"
+    },
+    {
+      "id": "5dfd3d4a-0216-4d48-97eb-f3f779a4aa37",
+      "sourceId": "df68d89c-d3a2-423e-b82a-6ad40e2560fb",
+      "type": "edge",
+      "targetId": "f97bbcc0-aae0-4844-82eb-bfa8a7a150e3"
+    }
+  ]
+}

--- a/rules/general-supplements/guidedogsupplementpending.json
+++ b/rules/general-supplements/guidedogsupplementpending.json
@@ -31,7 +31,7 @@
                 "field": "guideDogDocumentationType",
                 "description": "The type of documentation received for the guide dog.",
                 "dataType": "text-input",
-                "validationCriteria": "certification, testBooked, certifiedRetired",
+                "validationCriteria": "certifiedActive, testBooked, certifiedRetired",
                 "validationType": "[=text]"
               }
             ]
@@ -216,19 +216,9 @@
       "content": {
         "expressions": [
           {
-            "id": "eda9de75-be42-470e-8538-99aea2de0d00",
-            "key": "certified",
-            "value": "count(guideOrServiceDogTeams, (#.guideDogDocumentationType == 'certification'))"
-          },
-          {
             "id": "7c89301f-b8a0-4f0b-99ef-a5c0bdd1bf08",
             "key": "pending",
             "value": "count(guideOrServiceDogTeams, (#.guideDogDocumentationType == 'testBooked'))"
-          },
-          {
-            "id": "a580083f-8854-49b1-b5bc-317045c966d1",
-            "key": "retired",
-            "value": "count(guideOrServiceDogTeams, (#.guideDogDocumentationType == 'certifiedRetired'))"
           }
         ]
       },
@@ -298,7 +288,7 @@
       "content": {
         "kind": "noteNode",
         "config": {
-          "value": "Determines eligibility for a temporary supplement for guide dog teams where the a test has been booked for a guide dog team, but they are not yet certified."
+          "value": "Determines eligibility for a temporary supplement for guide dog teams where a test has been booked for a guide dog team, but they are not yet certified."
         }
       },
       "id": "02c994c5-18b5-4cf1-a98c-c7da69844426",


### PR DESCRIPTION
Adding guidedogsupplementpending.json
This supplement is related to the standard guidedogsupplement, but is for temporary/pending test guide dog teams. This rule evaluates if any dog teams are 'testbooked', and returns the total supplement amount for these teams, as well as an 'two month eligiblity' date.
Review: https://brms-simulator.apps.silver.devops.gov.bc.ca/rule/671bc9cdc092435f221a9e90?version=inReview